### PR TITLE
(#167) Improve robustness of hosts list

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -5,7 +5,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go: [1.17]
+        go: [1.17, 1.18]
 
     runs-on: ubuntu-latest
     steps:

--- a/cmd/provisioner.go
+++ b/cmd/provisioner.go
@@ -21,7 +21,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/sirupsen/logrus"
 
-	"gopkg.in/alecthomas/kingpin.v2"
+	"github.com/choria-io/fisk"
 )
 
 var (
@@ -35,7 +35,7 @@ var (
 )
 
 func Run() {
-	app := kingpin.New("choria-provisioner", "The Choria Provisioning Framework")
+	app := fisk.New("choria-provisioner", "The Choria Provisioning Framework")
 	app.Version(config.Version)
 	app.Author("R.I.Pienaar <rip@devco.net>")
 
@@ -46,7 +46,7 @@ func Run() {
 	cmd.Flag("choria-config", "Choria configuration file").Default(choria.UserConfig()).ExistingFileVar(&ccfile)
 	cmd.Flag("pid", "Write running PID to a file").StringVar(&pidFile)
 
-	command := kingpin.MustParse(app.Parse(os.Args[1:]))
+	command := fisk.MustParse(app.Parse(os.Args[1:]))
 
 	ctx, cancel = context.WithCancel(context.Background())
 	defer cancel()
@@ -59,10 +59,10 @@ func Run() {
 
 func run() {
 	cfg, err := config.Load(cfile)
-	kingpin.FatalIfError(err, "Provisioning could not be configured: %s", err)
+	fisk.FatalIfError(err, "Provisioning could not be configured: %s", err)
 
 	ccfg, err := cconf.NewConfig(ccfile)
-	kingpin.FatalIfError(err, "Could not load Choria Configuration: %s", err)
+	fisk.FatalIfError(err, "Could not load Choria Configuration: %s", err)
 
 	ccfg.LogLevel = cfg.Loglevel
 	ccfg.LogFile = cfg.Logfile
@@ -85,7 +85,7 @@ func run() {
 	}
 
 	fw, err := choria.NewWithConfig(ccfg)
-	kingpin.FatalIfError(err, "Provisioning could not configure Choria: %s", err)
+	fisk.FatalIfError(err, "Provisioning could not configure Choria: %s", err)
 
 	log = fw.Logger("provisioner")
 
@@ -101,7 +101,7 @@ func run() {
 	}
 
 	err = hosts.Process(ctx, cfg, fw)
-	kingpin.FatalIfError(err, "Provisioning could not start: %s", err)
+	fisk.FatalIfError(err, "Provisioning could not start: %s", err)
 }
 
 func writePID(pidfile string) {
@@ -110,7 +110,7 @@ func writePID(pidfile string) {
 	}
 
 	err := ioutil.WriteFile(pidfile, []byte(fmt.Sprintf("%d", os.Getpid())), 0644)
-	kingpin.FatalIfError(err, "Could not write PID: %s", err)
+	fisk.FatalIfError(err, "Could not write PID: %s", err)
 }
 
 func interruptHandler(ctx context.Context, cancel func()) {

--- a/go.mod
+++ b/go.mod
@@ -3,13 +3,13 @@ module github.com/choria-io/provisioner
 go 1.17
 
 require (
+	github.com/choria-io/fisk v0.1.1
 	github.com/choria-io/go-choria v0.25.2-0.20220611152103-61b1442fabea
 	github.com/ghodss/yaml v1.0.0
 	github.com/onsi/ginkgo/v2 v2.1.4
 	github.com/onsi/gomega v1.19.0
 	github.com/prometheus/client_golang v1.12.2
 	github.com/sirupsen/logrus v1.8.1
-	gopkg.in/alecthomas/kingpin.v2 v2.2.6
 )
 
 require (
@@ -18,12 +18,9 @@ require (
 	github.com/Masterminds/semver v1.5.0 // indirect
 	github.com/OneOfOne/xxhash v1.2.8 // indirect
 	github.com/agnivade/levenshtein v1.0.1 // indirect
-	github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751 // indirect
-	github.com/alecthomas/units v0.0.0-20211218093645-b94a6e3cc137 // indirect
 	github.com/antonmedv/expr v1.9.0 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.1.2 // indirect
-	github.com/choria-io/fisk v0.1.1 // indirect
 	github.com/cloudevents/sdk-go/v2 v2.10.1 // indirect
 	github.com/dustin/go-humanize v1.0.0 // indirect
 	github.com/fatih/color v1.13.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -119,13 +119,10 @@ github.com/agnivade/levenshtein v1.0.1 h1:3oJU7J3FGFmyhn8KHjmVaZCN5hxTr7GxgRue+s
 github.com/agnivade/levenshtein v1.0.1/go.mod h1:CURSv5d9Uaml+FovSIICkLbAUZ9S4RqaHDIsdSBg7lM=
 github.com/ajstarks/svgo v0.0.0-20180226025133-644b8db467af/go.mod h1:K08gAheRH3/J6wwsYMMT4xOr94bZjxIelGM0+d/wbFw=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
-github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751 h1:JYp7IbQjafoB+tBA3gMyHYHrpOtNuDiK/uB5uXxq5wM=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d/go.mod h1:rBZYJk541a8SKzHPHnH3zbiI+7dagKZ0cgpgrD7Fyho=
-github.com/alecthomas/units v0.0.0-20211218093645-b94a6e3cc137 h1:s6gZFSlWYmbqAuRjVTiNNhvNRfY2Wxp9nhfyel4rklc=
-github.com/alecthomas/units v0.0.0-20211218093645-b94a6e3cc137/go.mod h1:OMCwj8VM1Kc9e19TLln2VL61YJF0x1XFtfdL4JdbSyE=
 github.com/alessio/shellescape v1.4.1/go.mod h1:PZAiSCk0LJaZkiCSkPv8qIobYglO3FPpyFjDCtHLS30=
 github.com/alexflint/go-filemutex v0.0.0-20171022225611-72bdc8eae2ae/go.mod h1:CgnQgUtFrFz9mxFNtED3jI5tLDjKlOM+oUF/sTk6ps0=
 github.com/alexflint/go-filemutex v1.1.0/go.mod h1:7P4iRhttt/nUvUOrYIhcpMzv2G6CY9UnI16Z+UJqRyk=
@@ -1664,7 +1661,6 @@ google.golang.org/protobuf v1.27.1/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQ
 google.golang.org/protobuf v1.28.0 h1:w43yiav+6bVFTBQFZX0r7ipe9JQ1QsbMgHwbBziscLw=
 google.golang.org/protobuf v1.28.0/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
 gopkg.in/airbrake/gobrake.v2 v2.0.9/go.mod h1:/h5ZAUhDkGaJfjzjKLSjv6zCL6O0LLBxU4K+aSYdM/U=
-gopkg.in/alecthomas/kingpin.v2 v2.2.6 h1:jMFz6MfLP0/4fUyZle81rXUoxOBFi19VUFKVDOQfozc=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/alessio/shellescape.v1 v1.0.0-20170105083845-52074bc9df61/go.mod h1:IfMagxm39Ys4ybJrDb7W3Ob8RwxftP0Yy+or/NVz1O8=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/host/host.go
+++ b/host/host.go
@@ -45,12 +45,13 @@ type Host struct {
 	edPubK          string
 	signedServerJWT string
 
-	cfg       *config.Config
-	token     string
-	fw        *choria.Framework
-	log       *logrus.Entry
-	mu        *sync.Mutex
-	replylock *sync.Mutex
+	Discovered time.Time `json:"-"`
+	cfg        *config.Config
+	token      string
+	fw         *choria.Framework
+	log        *logrus.Entry
+	mu         *sync.Mutex
+	replylock  *sync.Mutex
 }
 
 func NewHost(identity string, conf *config.Config) *Host {
@@ -74,6 +75,15 @@ func (h *Host) Provision(ctx context.Context, fw *choria.Framework) error {
 
 	h.fw = fw
 	h.log = fw.Logger(h.Identity)
+
+	if !h.Discovered.IsZero() {
+		since := time.Since(h.Discovered)
+		if since > 2*h.cfg.IntervalDuration {
+			h.log.Infof("Skipping node that has been on the list %v", since)
+		}
+
+		return nil
+	}
 
 	if h.cfg.Features.JWT {
 		err := h.fetchJWT(ctx)

--- a/hosts/stats.go
+++ b/hosts/stats.go
@@ -41,6 +41,11 @@ var (
 		Name: "choria_provisioner_provisioned",
 		Help: "How many nodes were successfully provisioned",
 	}, []string{"site"})
+
+	waitingGauge = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "choria_provisioner_work_queue_entries",
+		Help: "Number of nodes on the work queue waiting to be provisioned",
+	}, []string{"site"})
 )
 
 func init() {
@@ -51,4 +56,5 @@ func init() {
 	prometheus.MustRegister(provErrCtr)
 	prometheus.MustRegister(busyWorkerGauge)
 	prometheus.MustRegister(provisionedCtr)
+	prometheus.MustRegister(waitingGauge)
 }


### PR DESCRIPTION
We now track when an entry got onto the list and later just skip
entries that hass been there for more than 2 discovery intervals, this
will clear the list of old things automagically reasonably well
without having to do massive surgery on the structure of the list

Also move to fisk.

Signed-off-by: R.I.Pienaar <rip@devco.net>