### PR TITLE
(#167) Improve robustness of hosts list

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -5,7 +5,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go: [1.17]
+        go: [1.17, 1.18]
 
     runs-on: ubuntu-latest
     steps:

--- a/cmd/provisioner.go
+++ b/cmd/provisioner.go
@@ -21,7 +21,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/sirupsen/logrus"
 
-	"gopkg.in/alecthomas/kingpin.v2"
+	"github.com/choria-io/fisk"
 )
 
 var (
@@ -35,7 +35,7 @@ var (
 )
 
 func Run() {
-	app := kingpin.New("choria-provisioner", "The Choria Provisioning Framework")
+	app := fisk.New("choria-provisioner", "The Choria Provisioning Framework")
 	app.Version(config.Version)
 	app.Author("R.I.Pienaar <rip@devco.net>")
 
@@ -46,7 +46,7 @@ func Run() {
 	cmd.Flag("choria-config", "Choria configuration file").Default(choria.UserConfig()).ExistingFileVar(&ccfile)
 	cmd.Flag("pid", "Write running PID to a file").StringVar(&pidFile)
 
-	command := kingpin.MustParse(app.Parse(os.Args[1:]))
+	command := fisk.MustParse(app.Parse(os.Args[1:]))
 
 	ctx, cancel = context.WithCancel(context.Background())
 	defer cancel()
@@ -59,10 +59,10 @@ func Run() {
 
 func run() {
 	cfg, err := config.Load(cfile)
-	kingpin.FatalIfError(err, "Provisioning could not be configured: %s", err)
+	fisk.FatalIfError(err, "Provisioning could not be configured: %s", err)
 
 	ccfg, err := cconf.NewConfig(ccfile)
-	kingpin.FatalIfError(err, "Could not load Choria Configuration: %s", err)
+	fisk.FatalIfError(err, "Could not load Choria Configuration: %s", err)
 
 	ccfg.LogLevel = cfg.Loglevel
 	ccfg.LogFile = cfg.Logfile
@@ -85,7 +85,7 @@ func run() {
 	}
 
 	fw, err := choria.NewWithConfig(ccfg)
-	kingpin.FatalIfError(err, "Provisioning could not configure Choria: %s", err)
+	fisk.FatalIfError(err, "Provisioning could not configure Choria: %s", err)
 
 	log = fw.Logger("provisioner")
 
@@ -101,7 +101,7 @@ func run() {
 	}
 
 	err = hosts.Process(ctx, cfg, fw)
-	kingpin.FatalIfError(err, "Provisioning could not start: %s", err)
+	fisk.FatalIfError(err, "Provisioning could not start: %s", err)
 }
 
 func writePID(pidfile string) {
@@ -110,7 +110,7 @@ func writePID(pidfile string) {
 	}
 
 	err := ioutil.WriteFile(pidfile, []byte(fmt.Sprintf("%d", os.Getpid())), 0644)
-	kingpin.FatalIfError(err, "Could not write PID: %s", err)
+	fisk.FatalIfError(err, "Could not write PID: %s", err)
 }
 
 func interruptHandler(ctx context.Context, cancel func()) {

--- a/go.mod
+++ b/go.mod
@@ -3,13 +3,13 @@ module github.com/choria-io/provisioner
 go 1.17
 
 require (
+	github.com/choria-io/fisk v0.1.1
 	github.com/choria-io/go-choria v0.25.2-0.20220611152103-61b1442fabea
 	github.com/ghodss/yaml v1.0.0
 	github.com/onsi/ginkgo/v2 v2.1.4
 	github.com/onsi/gomega v1.19.0
 	github.com/prometheus/client_golang v1.12.2
 	github.com/sirupsen/logrus v1.8.1
-	gopkg.in/alecthomas/kingpin.v2 v2.2.6
 )
 
 require (
@@ -18,12 +18,9 @@ require (
 	github.com/Masterminds/semver v1.5.0 // indirect
 	github.com/OneOfOne/xxhash v1.2.8 // indirect
 	github.com/agnivade/levenshtein v1.0.1 // indirect
-	github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751 // indirect
-	github.com/alecthomas/units v0.0.0-20211218093645-b94a6e3cc137 // indirect
 	github.com/antonmedv/expr v1.9.0 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.1.2 // indirect
-	github.com/choria-io/fisk v0.1.1 // indirect
 	github.com/cloudevents/sdk-go/v2 v2.10.1 // indirect
 	github.com/dustin/go-humanize v1.0.0 // indirect
 	github.com/fatih/color v1.13.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -119,13 +119,10 @@ github.com/agnivade/levenshtein v1.0.1 h1:3oJU7J3FGFmyhn8KHjmVaZCN5hxTr7GxgRue+s
 github.com/agnivade/levenshtein v1.0.1/go.mod h1:CURSv5d9Uaml+FovSIICkLbAUZ9S4RqaHDIsdSBg7lM=
 github.com/ajstarks/svgo v0.0.0-20180226025133-644b8db467af/go.mod h1:K08gAheRH3/J6wwsYMMT4xOr94bZjxIelGM0+d/wbFw=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
-github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751 h1:JYp7IbQjafoB+tBA3gMyHYHrpOtNuDiK/uB5uXxq5wM=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d/go.mod h1:rBZYJk541a8SKzHPHnH3zbiI+7dagKZ0cgpgrD7Fyho=
-github.com/alecthomas/units v0.0.0-20211218093645-b94a6e3cc137 h1:s6gZFSlWYmbqAuRjVTiNNhvNRfY2Wxp9nhfyel4rklc=
-github.com/alecthomas/units v0.0.0-20211218093645-b94a6e3cc137/go.mod h1:OMCwj8VM1Kc9e19TLln2VL61YJF0x1XFtfdL4JdbSyE=
 github.com/alessio/shellescape v1.4.1/go.mod h1:PZAiSCk0LJaZkiCSkPv8qIobYglO3FPpyFjDCtHLS30=
 github.com/alexflint/go-filemutex v0.0.0-20171022225611-72bdc8eae2ae/go.mod h1:CgnQgUtFrFz9mxFNtED3jI5tLDjKlOM+oUF/sTk6ps0=
 github.com/alexflint/go-filemutex v1.1.0/go.mod h1:7P4iRhttt/nUvUOrYIhcpMzv2G6CY9UnI16Z+UJqRyk=
@@ -1664,7 +1661,6 @@ google.golang.org/protobuf v1.27.1/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQ
 google.golang.org/protobuf v1.28.0 h1:w43yiav+6bVFTBQFZX0r7ipe9JQ1QsbMgHwbBziscLw=
 google.golang.org/protobuf v1.28.0/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
 gopkg.in/airbrake/gobrake.v2 v2.0.9/go.mod h1:/h5ZAUhDkGaJfjzjKLSjv6zCL6O0LLBxU4K+aSYdM/U=
-gopkg.in/alecthomas/kingpin.v2 v2.2.6 h1:jMFz6MfLP0/4fUyZle81rXUoxOBFi19VUFKVDOQfozc=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/alessio/shellescape.v1 v1.0.0-20170105083845-52074bc9df61/go.mod h1:IfMagxm39Ys4ybJrDb7W3Ob8RwxftP0Yy+or/NVz1O8=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/host/rpc.go
+++ b/host/rpc.go
@@ -251,7 +251,7 @@ func (h *Host) fetchJWT(ctx context.Context) (err error) {
 		return nil
 	}
 
-	return h.provisionClient(ctx, "jwt", 5, func(ctx context.Context, pc *provclient.ChoriaProvisionClient) error {
+	return h.provisionClient(ctx, "jwt", 3, func(ctx context.Context, pc *provclient.ChoriaProvisionClient) error {
 		h.log.Info("Fetching JWT")
 
 		res, err := pc.Jwt(h.token).Do(ctx)

--- a/hosts/hosts.go
+++ b/hosts/hosts.go
@@ -12,11 +12,9 @@ import (
 
 	"github.com/choria-io/go-choria/inter"
 	"github.com/choria-io/go-choria/lifecycle"
-	addl "github.com/choria-io/go-choria/providers/agent/mcorpc/ddl/agent"
 
 	"github.com/choria-io/go-choria/choria"
 	"github.com/choria-io/go-choria/client/client"
-	rpc "github.com/choria-io/go-choria/providers/agent/mcorpc/client"
 	"github.com/choria-io/go-choria/providers/discovery/broadcast"
 	"github.com/choria-io/provisioner/config"
 	"github.com/choria-io/provisioner/host"
@@ -41,16 +39,6 @@ func Process(ctx context.Context, cfg *config.Config, cfw *choria.Framework) err
 	log = fw.Logger("hosts")
 
 	log.Infof("Choria Provisioner starting using configuration file %s. Discovery interval %s using %d workers", conf.File, conf.Interval, conf.Workers)
-
-	ddl, err := addl.CachedDDL("choria_provision")
-	if err != nil {
-		return fmt.Errorf("could not find DDL for agent choria_provision in the agent cache")
-	}
-
-	agent, err := rpc.New(fw, "choria_provision", rpc.DDL(ddl))
-	if err != nil {
-		return fmt.Errorf("could not create RPC client: %s", err)
-	}
 
 	conn, err := connect(ctx)
 	if err != nil {
@@ -86,16 +74,17 @@ func Process(ctx context.Context, cfg *config.Config, cfw *choria.Framework) err
 
 	discoveredCtr.WithLabelValues(conf.Site).Add(0.0)
 	provisionedCtr.WithLabelValues(conf.Site).Add(0.0)
+	waitingGauge.WithLabelValues(conf.Site).Set(0.0)
 
-	discover(ctx, agent)
+	discover(ctx)
 
 	for {
 		select {
 		case <-timer.C:
-			discover(ctx, agent)
+			discover(ctx)
 
 		case <-discoverTrigger:
-			discover(ctx, agent)
+			discover(ctx)
 
 		case <-ctx.Done():
 			log.Infof("Existing on context interrupt")
@@ -123,31 +112,34 @@ func remove(host *host.Host) {
 	defer mu.Unlock()
 
 	delete(hosts, host.Identity)
+
+	waitingGauge.WithLabelValues(conf.Site).Set(float64(len(work)))
 }
 
 func add(host *host.Host) bool {
 	mu.Lock()
 	defer mu.Unlock()
 
-	if len(work) == cap(work) {
-		log.Warnf("Work queue is full at %d entries, cannot add %s", len(work), host.Identity)
-		return false
-	}
-
 	_, known := hosts[host.Identity]
 	if known {
 		return false
 	}
 
-	log.Debugf("Adding %s to the work queue with %d entries", host.Identity, len(hosts))
+	log.Infof("Adding %s to the work queue with %d entries", host.Identity, len(hosts))
 	hosts[host.Identity] = host
 
-	work <- host
+	select {
+	case work <- host:
+	default:
+		log.Warnf("Adding host to work queue failed with %d / %d entries", len(work), cap(work))
+	}
+
+	waitingGauge.WithLabelValues(conf.Site).Set(float64(len(work)))
 
 	return true
 }
 
-func discover(ctx context.Context, agent *rpc.RPC) {
+func discover(ctx context.Context) {
 	if conf.Paused() {
 		log.Warnf("Skipping discovery while paused")
 		return
@@ -155,14 +147,14 @@ func discover(ctx context.Context, agent *rpc.RPC) {
 
 	discoverCycleCtr.WithLabelValues(conf.Site).Inc()
 
-	err := discoverProvisionableNodes(ctx, agent)
+	err := discoverProvisionableNodes(ctx)
 	if err != nil {
 		errCtr.WithLabelValues(conf.Site).Inc()
 		log.Errorf("Could not discover nodes: %s", err)
 	}
 }
 
-func discoverProvisionableNodes(ctx context.Context, agent *rpc.RPC) error {
+func discoverProvisionableNodes(ctx context.Context) error {
 	log.Infof("Looking for provisionable hosts")
 
 	f, err := client.NewFilter(client.AgentFilter("choria_provision"))
@@ -171,13 +163,16 @@ func discoverProvisionableNodes(ctx context.Context, agent *rpc.RPC) error {
 	}
 
 	bd := broadcast.New(fw)
-	nodes, err := bd.Discover(ctx, broadcast.Collective("provisioning"), broadcast.Filter(f), broadcast.Timeout(1*time.Second))
+	nodes, err := bd.Discover(ctx, broadcast.Collective("provisioning"), broadcast.Filter(f), broadcast.SlidingWindow(), broadcast.Timeout(2*time.Second))
 	if err != nil {
 		return err
 	}
 
 	for _, n := range nodes {
-		if add(host.NewHost(n, conf)) {
+		h := host.NewHost(n, conf)
+		h.Discovered = time.Now()
+
+		if add(h) {
 			log.Infof("Adding %s to the provision list after discovering it", n)
 			discoveredCtr.WithLabelValues(conf.Site).Inc()
 		}

--- a/hosts/provisioner.go
+++ b/hosts/provisioner.go
@@ -26,13 +26,11 @@ func provisioner(ctx context.Context, wg *sync.WaitGroup, i int) {
 			if err != nil {
 				provErrCtr.WithLabelValues(conf.Site).Inc()
 				log.Errorf("Could not provision %s: %s", host.Identity, err)
-			}
-
-			// delay removing the node to avoid a race between discovery and node restarting splay
-			go func() {
-				<-time.NewTimer(60 * time.Second).C
 				done <- host
-			}()
+			} else {
+				log.Infof("Provisioned %s", host.Identity)
+				time.AfterFunc(60*time.Second, func() { done <- host })
+			}
 
 		case <-ctx.Done():
 			log.Infof("Worker %d exiting on context", i)

--- a/hosts/stats.go
+++ b/hosts/stats.go
@@ -41,6 +41,11 @@ var (
 		Name: "choria_provisioner_provisioned",
 		Help: "How many nodes were successfully provisioned",
 	}, []string{"site"})
+
+	waitingGauge = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "choria_provisioner_work_queue_entries",
+		Help: "Number of nodes on the work queue waiting to be provisioned",
+	}, []string{"site"})
 )
 
 func init() {
@@ -51,4 +56,5 @@ func init() {
 	prometheus.MustRegister(provErrCtr)
 	prometheus.MustRegister(busyWorkerGauge)
 	prometheus.MustRegister(provisionedCtr)
+	prometheus.MustRegister(waitingGauge)
 }


### PR DESCRIPTION
We now track when an entry got onto the list and later just skip
entries that hass been there for more than 2 discovery intervals, this
will clear the list of old things automagically reasonably well
without having to do massive surgery on the make up of the list

Signed-off-by: R.I.Pienaar <rip@devco.net>